### PR TITLE
make db migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |id|integer|null: false|
 |name|string|null: false unique: true|
 |phone_number|integer|null:false|
-|E-mail|string|null:false,unique: true|
+|email|string|null:false,unique: true|
 |address|string|null:false|
 |introduce|text|
 |todo|text|
@@ -24,7 +24,7 @@ has_many : comments
 |item_id|integer|null:false|
 |transfortation_type|string|null:false|
 |days|integer|null:false|
-|status|integer|nall:false|
+|status|integer|null:false|
 
 
 ### asociation
@@ -33,7 +33,7 @@ belong_to : users
 
 
 ## コメント
-statusカラムはenumを使いましょう！
+statusカラムはenumを使う
 
 
 
@@ -50,26 +50,17 @@ statusカラムはenumを使いましょう！
 belong_to : users
 belong_to : transactions
 has_many : comments
-belong_to : categories
 
 
 
 ## commentsテーブル
 |Column|Type|Opitions|
 |------|----|--------|
-|user_id|string|null: false|
-|item_id|string|null: false|
+|user_id|integer|null: false|
+|item_id|integer|null: false|
 |body|text|
 
 ### association
 belong_to : items
 belong_to : users
 
-## categoriesテーブル
-|Column|Type|Opitions|
-|------|----|--------|
-|name|string|null:false|
-
-
-### association
-has_many :items

--- a/db/migrate/20170902080104_users.rb
+++ b/db/migrate/20170902080104_users.rb
@@ -1,0 +1,15 @@
+class Users < ActiveRecord::Migration[5.0]
+  def change
+
+    create_table :users do |t|
+      t.string   :name, null: false, unique: true
+      t.integer  :phone_number, null: false
+      t.string   :email, null: false, unique: true
+      t.string   :address, null: false
+      t.text     :introduce
+      t.text     :todo
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170902083613_transactions.rb
+++ b/db/migrate/20170902083613_transactions.rb
@@ -1,0 +1,13 @@
+class Transactions < ActiveRecord::Migration[5.0]
+  def change
+
+    create_table :transactions do |t|
+      t.integer   :item_id, null: false
+      t.string    :transfortation_type, null:false
+      t.integer   :days, null:false
+      t.integer     :staus, null:false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170902084313_items.rb
+++ b/db/migrate/20170902084313_items.rb
@@ -1,0 +1,14 @@
+class Items < ActiveRecord::Migration[5.0]
+  def change
+
+    create_table :items do |t|
+      t.string    :name, null:false, unique: true
+      t.string    :image, null:false
+      t.text      :body
+      t.integer   :price, null:false
+      t.integer   :category_id, null:false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170902084830_comments.rb
+++ b/db/migrate/20170902084830_comments.rb
@@ -1,0 +1,11 @@
+class Comments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :comments do |t|
+      t.integer   :user_id, null: false
+      t.integer   :item_id, null: false
+      t.text      :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,53 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170902084830) do
+
+  create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id",                  null: false
+    t.integer  "item_id",                  null: false
+    t.text     "body",       limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",                      null: false
+    t.string   "image",                     null: false
+    t.text     "body",        limit: 65535
+    t.integer  "price",                     null: false
+    t.integer  "category_id",               null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  create_table "transactions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "item_id",             null: false
+    t.string   "transfortation_type", null: false
+    t.integer  "days",                null: false
+    t.integer  "staus",               null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+  end
+
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",                       null: false
+    t.integer  "phone_number",               null: false
+    t.string   "email",                      null: false
+    t.string   "address",                    null: false
+    t.text     "introduce",    limit: 65535
+    t.text     "todo",         limit: 65535
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+end


### PR DESCRIPTION
# what 
DB、マイグレーション作成
　  users
      transactions
      items
     comments
＆＆db設計の変更、削除
　　categoryを削除
　　実装機能では不要なため
　　間違え箇所の訂正

# why
   データをDBで管理するため
　MySQLで可視化できるようにするため
   実装機能では不要なため(category)