### PR TITLE
fix show's view

### DIFF
--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -26,8 +26,8 @@
       // width: 350px;
       // background-size: 50% 50%;
       &__image{
-        width     : 100%;
-        max-height: 346px;
+        width: 410px;
+        height: 350px;
         // max-width: 346px;
         overflow: hidden;
         object-fit: cover;


### PR DESCRIPTION
## what
詳細の画像サイズの調整
全ての画像を表示の際長方形にする

## why
画像によってサイズ感が変わるのが嫌だったから